### PR TITLE
Correct README: point to MCR registry url

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ docker run --rm --name codeql-container -e CODEQL_CLI_ARGS="resolve qlpacks"  mc
 
 ### Downloading a pre-built container
 
-We keep updating the docker image periodically and uploading it to the Microsoft Container Registry at: ```mcr.microsoft.com/codeql/codeql-container```.
+We keep updating the docker image periodically and uploading it to the Microsoft Container Registry at: ```mcr.microsoft.com/cstsectools/codeql-container```.
 
 You can pull the image by running the command:
 ```


### PR DESCRIPTION
Perhaps the hosted location of this container moved at one point. The container path in the README does not resolve:


```
$ docker pull mcr.microsoft.com/codeql/codeql-container:latest                                                                                                            
Error response from daemon: manifest for mcr.microsoft.com/codeql/codeql-container:latest not found: manifest unknown: manifest tagged by "latest" is not found
```

However the one found on [docker hub](https://hub.docker.com/_/microsoft-cstsectools-codeql-container) resolves:

```
$ docker pull mcr.microsoft.com/cstsectools/codeql-container
Using default tag: latest
latest: Pulling from cstsectools/codeql-container
a4a2a29f9ba4: Pull complete
127c9761dcba: Pull complete
d13bf203e905: Pull complete
4039240d2e0b: Pull complete
1acbce47bb24: Pull complete
e23586ca5e36: Pull complete
5aa0d4e0b947: Pull complete
5059aff51e18: Pull complete
3de87a585326: Pull complete
81bcb87b35ea: Pull complete
ef1bf140eaca: Pull complete
779801fdb9d4: Pull complete
d44de807e946: Pull complete
6209b0b73919: Pull complete
bbf5a6ad14c8: Pull complete
caf663a973b6: Pull complete
6041a5a6ae72: Pull complete
Digest: sha256:2d47830c4bc095b0654fa756b600cec3af7c138384839239ba5b8b1428511a6c
Status: Downloaded newer image for mcr.microsoft.com/cstsectools/codeql-container:latest
mcr.microsoft.com/cstsectools/codeql-container:latest
```