### PR TITLE
fix(version): update regex for version check

### DIFF
--- a/container/libs/codeql.py
+++ b/container/libs/codeql.py
@@ -70,6 +70,8 @@ class CodeQL:
             exit(ERROR_EXECUTING_CODEQL)
         version_match = search("Version: ([0-9.]+)\.", ret_string)
         if not version_match:
+            version_match = search("release ([0-9.]+)\.", ret_string)
+        if not version_match:
             logger.error("Could not determine existing codeql version")
             exit(ERROR_EXECUTING_CODEQL)
         version = f'v{version_match.group(1)}'


### PR DESCRIPTION
Update the version detect for recent codeql output. Left the old code in place, in case you want to use older versions of codeql.

fixes #15 