### PR TITLE
Fix: Access function through self

### DIFF
--- a/container/libs/codeql.py
+++ b/container/libs/codeql.py
@@ -85,7 +85,7 @@ class CodeQL:
         ret1 = check_output_wrapper(f'unzip {download_path} -d {codeql_dir}', shell=True)
         
     def precompile_queries(self):
-        execute_codeql_command(f' query compile --search-path {self.CODEQL_HOME} {self.CODEQL_HOME}/codeql-repo/*/ql/src/codeql-suites/*.qls')
+        self.execute_codeql_command(f' query compile --search-path {self.CODEQL_HOME} {self.CODEQL_HOME}/codeql-repo/*/ql/src/codeql-suites/*.qls')
 
     def execute_codeql_command(self, args):
         ret_string = check_output_wrapper(f'{self.CODEQL_HOME}/codeql/codeql {args}', shell=True)


### PR DESCRIPTION
Fixes `NameError: name 'execute_codeql_command' is not defined`
Should be merged along with #28 