### PR TITLE
Update codeql.py

### DIFF
--- a/container/libs/codeql.py
+++ b/container/libs/codeql.py
@@ -68,7 +68,7 @@ class CodeQL:
         if ret_string is CalledProcessError:
             logger.error("Could not run codeql command")
             exit(ERROR_EXECUTING_CODEQL)
-        version_match = search("Version: ([0-9.]+)\.", ret_string)
+        version_match = search("release ([0-9.]+)\.", ret_string)
         if not version_match:
             logger.error("Could not determine existing codeql version")
             exit(ERROR_EXECUTING_CODEQL)


### PR DESCRIPTION
Changing "Version:" to "release" matches the actual CLI output of the version string in codeql and fixes the following error I was receiving in a project:

```
Could not determine existing codeql version
Traceback (most recent call last):
  File "/usr/local/startup_scripts/setup.py", line 57, in <module>
    setup()
  File "/usr/local/startup_scripts/setup.py", line 39, in setup
    get_latest_codeql(args)
  File "/usr/local/startup_scripts/setup.py", line 44, in get_latest_codeql
    current_installed_version = codeql.get_current_local_version()
  File "/usr/local/startup_scripts/libs/codeql.py", line 74, in get_current_local_version
    exit(ERROR_EXECUTING_CODEQL)
NameError: name 'ERROR_EXECUTING_CODEQL' is not defined
Command Output:

Error 1 executing from command.
Exiting...
```