### PR TITLE
Support Authenticated GitHub Requests in Setup

### DIFF
--- a/container/libs/github.py
+++ b/container/libs/github.py
@@ -1,8 +1,14 @@
-﻿from datetime import datetime, MINYEAR
+﻿import os
+from datetime import datetime, MINYEAR
 from github import Github, GitRelease, Repository, GithubException
 
 def get_latest_github_repo_version(repo):
-    client = Github()
+    # check for a github token that may be used alongside the codeql cli to upload github results
+    # this will limit rate limting 403 errors on checking codeql versions, as the request will be authenticated if possible.
+    # by default codeql uses env var "GITHUB_TOKEN" to authenticate
+    # https://codeql.github.com/docs/codeql-cli/manual/github-upload-results/
+    access_token = os.getenv('GITHUB_TOKEN')
+    client = Github(access_token) if access_token != None else Github()
     repo = client.get_repo(repo)
     releases = repo.get_releases()
     latest_release = get_latest_github_release(releases)

--- a/container/setup.py
+++ b/container/setup.py
@@ -43,10 +43,12 @@ def get_latest_codeql(args):
     codeql = CodeQL(CODEQL_HOME)
     current_installed_version = codeql.get_current_local_version()
     logger.info(f'Current codeql version: {current_installed_version}')
-    latest_online_version = codeql.get_latest_codeql_github_version()
-    if current_installed_version != latest_online_version.title and args.check_latest_cli:
-        # we got a newer version online, download and install it
-        codeql.download_and_install_latest_codeql(latest_online_version)
+    # ensure we only query for the latest codeql cli version if we might actually update it
+    if args.check_latest_cli:
+        latest_online_version = codeql.get_latest_codeql_github_version()
+        if current_installed_version != latest_online_version.title:
+            # we got a newer version online, download and install it
+            codeql.download_and_install_latest_codeql(latest_online_version)
     # get the latest queries regardless (TODO: Optimize by storing and checking the last commit hash?)
     if args.check_latest_queries:
         codeql.download_and_install_latest_codeql_queries()


### PR DESCRIPTION
Using this container provides a great deal of portability, but after a certain amount of usage we ran into GitHub rate limiting in `setup.py` on container start:

```
Traceback (most recent call last):
  File "/usr/local/startup_scripts/setup.py", line 57, in <module>
    setup()
  File "/usr/local/startup_scripts/setup.py", line 39, in setup
    get_latest_codeql(args)
  File "/usr/local/startup_scripts/setup.py", line 46, in get_latest_codeql
    latest_online_version = codeql.get_latest_codeql_github_version()
  File "/usr/local/startup_scripts/libs/codeql.py", line 80, in get_latest_codeql_github_version
    return get_latest_github_repo_version("github/codeql-cli-binaries")
  File "/usr/local/startup_scripts/libs/github.py", line 8, in get_latest_github_repo_version
    latest_release = get_latest_github_release(releases)
  File "/usr/local/startup_scripts/libs/github.py", line 14, in get_latest_github_release
    for release in releases:
  File "/usr/local/lib/python3.8/dist-packages/github/PaginatedList.py", line 64, in __iter__
    newElements = self._grow()
  File "/usr/local/lib/python3.8/dist-packages/github/PaginatedList.py", line 76, in _grow
    newElements = self._fetchNextPage()
  File "/usr/local/lib/python3.8/dist-packages/github/PaginatedList.py", line 197, in _fetchNextPage
    headers, data = self.__requester.requestJsonAndCheck(
  File "/usr/local/lib/python3.8/dist-packages/github/Requester.py", line 275, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, self.__customConnection(url)))
  File "/usr/local/lib/python3.8/dist-packages/github/Requester.py", line 286, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.RateLimitExceededException: 403 {'message': "API rate limit exceeded for x.x.x.x. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)", 'documentation_url': 'https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting'}
Error 1 executing from command.
Exiting...
Command Output: 
[2022-12-07 15:14:37,788] INFO: Starting setup...
[2022-12-07 15:14:38,234] INFO: Current codeql version: v2.11.3
```

Our execution commands were all passing the `GITHUB_TOKEN` environment variable to docker run, as the intent was to also upload the results to a private GitHub repository. However, we have realized that the instantiation of PyGithub client doesn't pass in or make use of the same env variable for any authentication on requests to public repos to validate the CodeQL CLI version:
https://github.com/microsoft/codeql-container/blob/main/container/libs/github.py#L5

Within our organization, the rate-limiting by IP Address is only going to get worse, and there is no reason for us to not authenticate for these requests.

This Pull Request does the following:
- Moves the check for the latest CodeQL CLI version to occur only if `CHECK_LATEST_CODEQL_CLI` is true (whereas before it always checked and left the value unused).
- Checks for an environment variable called "GITHUB_TOKEN" and passes it into the PyGithub ctor to allow for authenticated requests.

The changes are pretty small, but I'm not sure next steps for testing/validation cross-platform, or if that is included in a build process.