### PR TITLE
[FIX] Prevent rate limiting by changing setup.py to only reach out to the GitHub api to get the latest codeql cli version if args.check_latest_cli is set

### DIFF
--- a/container/setup.py
+++ b/container/setup.py
@@ -39,14 +39,15 @@ def setup():
     get_latest_codeql(args)
     logger.info("End setup...")
 def get_latest_codeql(args):
-    # what version do we have?
     codeql = CodeQL(CODEQL_HOME)
-    current_installed_version = codeql.get_current_local_version()
-    logger.info(f'Current codeql version: {current_installed_version}')
-    latest_online_version = codeql.get_latest_codeql_github_version()
-    if current_installed_version != latest_online_version.title and args.check_latest_cli:
-        # we got a newer version online, download and install it
-        codeql.download_and_install_latest_codeql(latest_online_version)
+    # what version do we have?
+    if args.check_latest_cli:
+        current_installed_version = codeql.get_current_local_version()
+        logger.info(f'Current codeql version: {current_installed_version}')
+        latest_online_version = codeql.get_latest_codeql_github_version()
+        if current_installed_version != latest_online_version.title:
+            # we got a newer version online, download and install it
+            codeql.download_and_install_latest_codeql(latest_online_version)
     # get the latest queries regardless (TODO: Optimize by storing and checking the last commit hash?)
     if args.check_latest_queries:
         codeql.download_and_install_latest_codeql_queries()


### PR DESCRIPTION
Before this change, it would always call `codeql.get_latest_codeql_github_version()` and only check if it should actually do anything with it afterwards based on `args.check_latest_cli`. This meant that it was required to hit the github API to get the latest codeql version regardless of `args.check_latest_cli` being set, which could lead to API ratelimiting and the setup script crashing before it could launch codeql. 

This change gates the `codeql.get_latest_codeql_github_version()` call behind a `args.check_latest_cli` to prevent unnecessary reliance on being able to reach the github API if the codeql latest version isn't going to be used because the `check_latest_cli` argument isn't set.