### PR TITLE
Adding TypeScript Support and Removing `github/codeql-go` References

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,32 +12,33 @@ RUN adduser --home ${CODEQL_HOME} ${USERNAME} && \
     apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y --no-install-recommends \
-    	software-properties-common \
-    	vim \
-    	curl \
-    	wget \
-    	git \
-    	build-essential \
-    	unzip \
-    	apt-transport-https \
-        python3.8 \
-    	python3-venv \
-    	python3-pip \
-    	python3-setuptools \
-        python3-dev \
-    	gnupg \
-    	g++ \
-    	make \
-    	gcc \
-    	apt-utils \
-        rsync \
-    	file \
-        dos2unix \
-    	gettext && \
-        apt-get clean && \
-        rm -f /usr/bin/python /usr/bin/pip && \
-        ln -s /usr/bin/python3.8 /usr/bin/python && \
-        ln -s /usr/bin/pip3 /usr/bin/pip 
+    software-properties-common \
+    nodejs \
+    vim \
+    curl \
+    wget \
+    git \
+    build-essential \
+    unzip \
+    apt-transport-https \
+    python3.8 \
+    python3-venv \
+    python3-pip \
+    python3-setuptools \
+    python3-dev \
+    gnupg \
+    g++ \
+    make \
+    gcc \
+    apt-utils \
+    rsync \
+    file \
+    dos2unix \
+    gettext && \
+    apt-get clean && \
+    rm -f /usr/bin/python /usr/bin/pip && \
+    ln -s /usr/bin/python3.8 /usr/bin/python && \
+    ln -s /usr/bin/pip3 /usr/bin/pip 
 
 # Install .NET Core and Java for tools/builds
 RUN cd /tmp && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -70,8 +70,6 @@ RUN mkdir -p \
 # get the latest codeql queries and record the HEAD
 RUN git clone --depth 1 https://github.com/github/codeql ${CODEQL_HOME}/codeql-repo && \
     git --git-dir ${CODEQL_HOME}/codeql-repo/.git log --pretty=reference -1 > /opt/codeql/codeql-repo-last-commit
-RUN git clone --depth 1 https://github.com/github/codeql-go ${CODEQL_HOME}/codeql-go-repo && \
-    git --git-dir ${CODEQL_HOME}/codeql-go-repo/.git log --pretty=reference -1 > /opt/codeql/codeql-go-repo-last-commit
 
 RUN CODEQL_VERSION=$(cat /tmp/codeql_version) && \
     wget -q https://github.com/github/codeql-cli-binaries/releases/download/${CODEQL_VERSION}/codeql-linux64.zip -O /tmp/codeql_linux.zip && \
@@ -82,7 +80,6 @@ ENV PATH="${CODEQL_HOME}/codeql:${PATH}"
 
 # Pre-compile our queries to save time later
 RUN codeql query compile --threads=0 ${CODEQL_HOME}/codeql-repo/*/ql/src/codeql-suites/*.qls --additional-packs=.
-RUN codeql query compile --threads=0 ${CODEQL_HOME}/codeql-go-repo/ql/src/codeql-suites/*.qls --additional-packs=.
 
 ENV PYTHONIOENCODING=utf-8
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -64,7 +64,6 @@ RUN pip3 install --upgrade pip \
 RUN python3 /usr/local/startup_scripts/get-latest-codeql-version.py > /tmp/codeql_version
 RUN mkdir -p \
     ${CODEQL_HOME}/codeql-repo \
-    ${CODEQL_HOME}/codeql-go-repo \
     /opt/codeql
 
 # get the latest codeql queries and record the HEAD


### PR DESCRIPTION
When scanning javascript project that use typeScript, we are getting the following error:
```
[build-stderr] Could not start Node.js. It is required for TypeScript extraction.                                                    
[build-stderr] Please install Node.js and ensure 'node' is on the PATH.
```
- This change adds `nodejs` to the `Dockerfile`.
- Additionally since `github/codeql-go` has now moved to `github/codeql` this change removes the relevant lines from the `Dockerfile`  See: https://github.com/github/codeql-go/issues/741