### PR TITLE
Dockerfile: install git-lfs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN adduser --home ${CODEQL_HOME} ${USERNAME} && \
     	curl \
     	wget \
     	git \
+        git-lfs \
     	build-essential \
     	unzip \
     	apt-transport-https \


### PR DESCRIPTION
This is required for repositories that
use git-lfs.